### PR TITLE
Update dependencies, separate Kotest Arrow Fx from Kotest Arrow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: 11
 
       - name: Build
-        uses: gradle/gradle-build-action@v2.2.5
+        uses: gradle/gradle-build-action@v2.3.0
         with:
           arguments: build
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-arrow = "1.1.3-alpha.46"
+arrow = "1.1.3-alpha.48"
 suspendapp = "0.3.0"
 arrowGradleConfig = "0.10.1"
 coroutines = "1.6.4"
@@ -9,14 +9,15 @@ kotest-plugin = "5.4.2"
 kover = "0.6.0"
 detekt = "1.21.0"
 ktor = "2.1.0"
-logback = "1.2.11"
+logback = "1.4.0"
 sqldelight = "2.0.0-alpha03"
 testcontainers = "1.17.3"
 hikari = "5.0.1"
-postgresql = "42.4.2"
-kotest-arrow = "1.1.0.128-SNAPSHOT"
+postgresql = "42.5.0"
+kotest-arrow = "1.2.5"
+kotest-arrow-fx = "1.1.0.145-SNAPSHOT"
 jib = "3.2.1"
-flyway = "9.1.6"
+flyway = "9.2.2"
 kotlin-logging = "2.1.23"
 avro4k = "1.6.0"
 kotlin-kafka = "0.3.0"
@@ -37,7 +38,7 @@ kotest-frameworkEngine = { module = "io.kotest:kotest-framework-engine", version
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 kotest-runnerJUnit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-arrow = { module = "io.kotest.extensions:kotest-assertions-arrow", version.ref = "kotest-arrow" }
-kotest-arrow-fx = { module = "io.kotest.extensions:kotest-assertions-arrow-fx-coroutines", version.ref = "kotest-arrow" }
+kotest-arrow-fx = { module = "io.kotest.extensions:kotest-assertions-arrow-fx-coroutines", version.ref = "kotest-arrow-fx" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }


### PR DESCRIPTION
Closes #27 

#27 was failing because Kotest Arrow is published with version 1.2.5 in Maven Central, but Kotest Arrow Fx isn't. This PR separates both versions, and updates all the dependencies to their latest versions.