### PR TITLE
Fixes on subscription action

### DIFF
--- a/src/main/kotlin/alerts/github/GithubClient.kt
+++ b/src/main/kotlin/alerts/github/GithubClient.kt
@@ -11,6 +11,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.plugins.resources.Resources
 import io.ktor.client.plugins.resources.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.resources.Resource as KtorRes
@@ -30,6 +31,7 @@ suspend fun ResourceScope.GithubClient(
 ): GithubClient {
   val client = autoCloseable {
     HttpClient {
+      install(Resources)
       install(HttpCache)
       install(DefaultRequest) { url(config.uri) }
     }
@@ -55,7 +57,7 @@ private class DefaultGithubClient(
   @Serializable
   @KtorRes("/repos/{owner}/{repo}")
   class Repo(val owner: String, val repo: String)
-  
+
   override suspend fun repositoryExists(owner: String, name: String): Either<GithubError, Boolean> = either {
     retryPolicy.retry {
       val response = httpClient.get(Repo(owner, name)) {

--- a/src/main/kotlin/alerts/subscription/persistence.kt
+++ b/src/main/kotlin/alerts/subscription/persistence.kt
@@ -42,9 +42,8 @@ class SqlDelightSubscriptionsPersistence(
     subscriptions.transactionWithResult {
       subscription.traverse { (repository, subscribedAt) ->
         val repoId =
-          repositories.insert(repository.owner, repository.name).executeAsOneOrNull() ?: repositories.selectId(
-            repository.owner, repository.name
-          ).executeAsOne()
+          repositories.selectId(repository.owner, repository.name).executeAsOneOrNull() ?:
+          repositories.insert(repository.owner, repository.name).executeAsOne()
         
         catch({
           subscriptions.insert(user, repoId, subscribedAt.toJavaLocalDateTime())


### PR DESCRIPTION
Fixes:
- Install Resources on httpClient, otherwise when invoking it will fail with: `Resources plugin is not installed`
- On subscription action, we should first check if the repository exists, and otherwise, insert it.